### PR TITLE
WIP: read literal values

### DIFF
--- a/fixtures/dotenv.bad
+++ b/fixtures/dotenv.bad
@@ -1,0 +1,7 @@
+#
+# Errors
+#
+
+NO_EQUALS
+SECRET4="foo\ bar"
+99_RED_BALLOONS=

--- a/fixtures/dotenv.txt
+++ b/fixtures/dotenv.txt
@@ -1,7 +1,6 @@
 #
 # Good
 #
-
 export FOO= # ignore me
 
 SECRET=foo''bar\ baz
@@ -12,12 +11,3 @@ SECRET2='foo\ bar'
 SECRET3="foo\\ bar"
 
 SECRET4="foo\\ bar$BAZ${QUX}"
-
-
-#
-# Errors
-#
-
-NO_EQUALS
-SECRET4="foo\ bar"
-99_RED_BALLOONS=

--- a/fixtures/dotenv.txt
+++ b/fixtures/dotenv.txt
@@ -1,8 +1,9 @@
 #
 # Good
 #
-export FOO= # ignore me
+export EMPTY= # ignore me
 
+FOO=bar
 SECRET=foo''bar\ baz
 
 SECRET2='foo\ bar'
@@ -10,4 +11,4 @@ SECRET2='foo\ bar'
 # "foo\\ bar" (in case the formatter eats it)
 SECRET3="foo\\ bar"
 
-SECRET4="foo\\ bar$BAZ${QUX}"
+SECRET4="foo\\ bar$FOO${PWD}$BAZ"

--- a/fixtures/dotenv.txt
+++ b/fixtures/dotenv.txt
@@ -1,0 +1,23 @@
+#
+# Good
+#
+
+export FOO= # ignore me
+
+SECRET=foo''bar\ baz
+
+SECRET2='foo\ bar'
+
+# "foo\\ bar" (in case the formatter eats it)
+SECRET3="foo\\ bar"
+
+SECRET4="foo\\ bar$BAZ${QUX}"
+
+
+#
+# Errors
+#
+
+NO_EQUALS
+SECRET4="foo\ bar"
+99_RED_BALLOONS=

--- a/src/main.zig
+++ b/src/main.zig
@@ -146,6 +146,7 @@ pub const Env = struct {
                                     },
                                     '=' => {
                                         state = .value;
+                                        // TODO read literal values
                                         break;
                                     },
                                     else => {

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,7 +292,9 @@ pub const Env = struct {
                         ' ', '\t' => {
                             // continuation of the output string 'MY_KEY='
                             std.debug.print("[{s}]{s}\n", .{ key_buf.items, val_buf.items });
-                            try env.map.put(env.allocator, key_buf.items, val_buf.items);
+                            var key = try env.allocator.dupe(u8, key_buf.items);
+                            var val = try env.allocator.dupe(u8, val_buf.items);
+                            try env.map.put(env.allocator, key, val);
                             //std.debug.print("{'}\n", .{std.zig.fmtEscapes(val_buf.items)});
                             var_buf.items.len = 0;
                             state = .chomp_eol;
@@ -308,7 +310,9 @@ pub const Env = struct {
                             }
                             // continuation of MY_KEY=
                             std.debug.print("[{s}]{s}\n", .{ key_buf.items, val_buf.items });
-                            try env.map.put(env.allocator, key_buf.items, val_buf.items);
+                            var key = try env.allocator.dupe(u8, key_buf.items);
+                            var val = try env.allocator.dupe(u8, val_buf.items);
+                            try env.map.put(env.allocator, key, val);
                             //std.debug.print("{'}\n", .{std.zig.fmtEscapes(val_buf.items)});
                             try writer.writeByte(char);
                             state = .chomp_prefix;


### PR DESCRIPTION
- [x] read a single literal values (single quotes)
- [x] loop through all values
- [ ] read unquoted values
- [ ] read expressions (double quotes)

States:
- start (consume whitespace and comments until key)
- consume whitespace (\r\n ends, otherwise whitespace or comment or error)
- consume literal (' to ', then quote or whitespace)
- consume expression (whitespace sensitive, including substitutions; allows escapes, including whitespace)
- consume quoted expression (substitutions and escapes, not whitespace sensitive until unescaped ")